### PR TITLE
Prefix decoration

### DIFF
--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -153,6 +153,12 @@ impl LauncherState {
             }
         }
 
+        tracing::debug!("Trying to process true prefix");
+        let true_prefix = match config.get_selected_wine() {
+            Ok(Some(version)) => version.prefix_path(&config.components.path, config.game.wine.prefix.clone()),
+            _ => config.game.wine.prefix.clone()
+        };
+
         let mut voices = Vec::with_capacity(config.game.voices.len());
 
         for voice in config.game.voices {
@@ -162,6 +168,6 @@ impl LauncherState {
             });
         }
 
-        Self::get(config.game.wine.prefix, config.game.path, voices, config.patch.servers, status)
+        Self::get(true_prefix, config.game.path, voices, config.patch.servers, status)
     }
 }


### PR DESCRIPTION
Add a prefix decoration field to features. This allows for Proton components, or any Proton derivative that would change things "just because" (looking at Epic exhaustingly), to communicate in which folder the WINE prefix *truly* resides, leaving prefix autodetection unchanged.