### PR TITLE
Fix gamescope 3.12 upscaling flags

### DIFF
--- a/src/config/schema_blanks/gamescope/mod.rs
+++ b/src/config/schema_blanks/gamescope/mod.rs
@@ -97,14 +97,14 @@ impl From<&JsonValue> for Gamescope {
 
 impl Gamescope {
     fn is_legacy_version() -> bool {
-        // gamescope doesn't have --version, so parsing --help 
+        // gamescope doesn't have --version, so parsing --help instead
         match Command::new("/usr/bin/gamescope").arg("--help").output() {
-            Err(_) => false,
+            Err(_) => true,
             Ok(output) => String::from_utf8(output.stderr)
                 .unwrap_or_default()
                 .lines()
                 .find(|s| s.contains("-F, --filter"))
-                .is_none() // if no --filter, then it's old version
+                .is_none() // if no --filter, then it's legacy version
         }
     }
 

--- a/src/config/schema_blanks/gamescope/mod.rs
+++ b/src/config/schema_blanks/gamescope/mod.rs
@@ -1,17 +1,20 @@
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, Deserialize};
 use serde_json::Value as JsonValue;
 
 use std::process::Command;
 
-pub mod framerate;
 pub mod size;
+
+pub mod framerate;
+
 pub mod window_type;
 
 pub mod prelude {
-    pub use super::framerate::Framerate;
-    pub use super::size::Size;
-    pub use super::window_type::WindowType;
     pub use super::Gamescope;
+    pub use super::size::Size;
+    pub use super::framerate::Framerate;
+
+    pub use super::window_type::WindowType;
 }
 
 use prelude::*;
@@ -98,7 +101,7 @@ impl Gamescope {
         match Command::new("/usr/bin/gamescope").arg("--help").output() {
             Err(_) => false,
             Ok(output) => String::from_utf8(output.stderr)
-                .unwrap()
+                .unwrap_or_default()
                 .lines()
                 .find(|s| s.contains("-F, --filter"))
                 .is_none() // if no --filter, then it's old version

--- a/src/config/schema_blanks/gamescope/mod.rs
+++ b/src/config/schema_blanks/gamescope/mod.rs
@@ -151,28 +151,28 @@ impl Gamescope {
 
             // Set integer scaling
             if self.integer_scaling {
-                if Gamescope::is_legacy_version() {
-                    gamescope += " -n";
+                gamescope += if Gamescope::is_legacy_version() {
+                    " -n"
                 } else {
-                    gamescope += " -F integer"
+                    " -F integer"
                 }
             }
 
             // Set FSR support
             if self.fsr {
-                if Gamescope::is_legacy_version() {
-                    gamescope += " -U";
+                gamescope += if Gamescope::is_legacy_version() {
+                    " -U"
                 } else {
-                    gamescope += " -F fsr"
+                    " -F fsr"
                 }
             }
 
             // Set NIS (Nvidia Image Scaling) support
             if self.nis {
-                if Gamescope::is_legacy_version() {
-                    gamescope += " -Y";
+                gamescope += if Gamescope::is_legacy_version() {
+                    " -Y"
                 } else {
-                    gamescope += " -F nis"
+                    " -F nis"
                 }
             }
 


### PR DESCRIPTION
Gamescope 3.12 changed its upscaling flags. 
```sh
~/ gamescope -U # fsr
gamescope: invalid option -- 'U'
See --help for a list of options.

~/ gamescope -F fsr # works
```

This pull request checks gamescope version and set correct flags.