### PR TITLE
Adding backend model and logic for FPS unlocker

### DIFF
--- a/src/config/schema_blanks/fps_star_rail.rs
+++ b/src/config/schema_blanks/fps_star_rail.rs
@@ -1,0 +1,40 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum FpsStarRail {
+    // 30
+    Thirty,
+
+    // 60
+    Sixty,
+
+    // 120
+    HundredTwenty
+}
+
+impl FpsStarRail {
+    pub fn list() -> Vec<Self> {
+        vec![
+            Self::Thirty,
+            Self::Sixty,
+            Self::HundredTwenty
+        ]
+    }
+
+    pub fn from_num(fps: u64) -> Self {
+        match fps {
+            30 => Self::Thirty,
+            60 => Self::Sixty,
+            120 => Self::HundredTwenty,
+            _   => Self::HundredTwenty
+        }
+    }
+
+    pub fn to_num(&self) -> u64 {
+        match self {
+            Self::Thirty => 30,
+            Self::Sixty => 60,
+            Self::HundredTwenty     => 120
+        }
+    }
+}

--- a/src/config/schema_blanks/mod.rs
+++ b/src/config/schema_blanks/mod.rs
@@ -12,6 +12,9 @@ pub mod gamescope;
 #[cfg(feature = "sandbox")]
 pub mod sandbox;
 
+#[cfg(feature = "fps-unlocker")]
+pub mod fps_star_rail;
+
 pub mod prelude {
     pub use super::resolution::Resolution;
     pub use super::repairer::Repairer;

--- a/src/games/star_rail/config/schema/game/enhancements.rs
+++ b/src/games/star_rail/config/schema/game/enhancements.rs
@@ -3,12 +3,18 @@ use serde_json::Value as JsonValue;
 
 use crate::config::schema_blanks::prelude::*;
 
+#[cfg(feature = "fps-unlocker")]
+use super::FpsUnlocker;
+
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Enhancements {
     pub fsr: Fsr,
     pub gamemode: bool,
     pub hud: HUD,
-    pub gamescope: Gamescope
+    pub gamescope: Gamescope,
+
+    #[cfg(feature = "fps-unlocker")]
+    pub fps_unlocker: FpsUnlocker
 }
 
 impl From<&JsonValue> for Enhancements {
@@ -30,7 +36,12 @@ impl From<&JsonValue> for Enhancements {
 
             gamescope: value.get("gamescope")
                 .map(Gamescope::from)
-                .unwrap_or(default.gamescope)
+                .unwrap_or(default.gamescope),
+
+            #[cfg(feature = "fps-unlocker")]
+            fps_unlocker: value.get("fps_unlocker")
+                .map(FpsUnlocker::from)
+                .unwrap_or(default.fps_unlocker)
         }
     }
 }

--- a/src/games/star_rail/config/schema/game/fps_unlocker/config.rs
+++ b/src/games/star_rail/config/schema/game/fps_unlocker/config.rs
@@ -1,0 +1,29 @@
+use serde::{Serialize, Deserialize};
+use serde_json::Value as JsonValue;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+    pub fps: u64
+}
+
+impl Default for Config {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            fps: 60
+        }
+    }
+}
+
+impl From<&JsonValue> for Config {
+    fn from(value: &JsonValue) -> Self {
+        let default = Self::default();
+
+        Self {
+            fps: match value.get("fps") {
+                Some(value) => value.as_u64().unwrap_or(default.fps),
+                None => default.fps
+            }
+        }
+    }
+}

--- a/src/games/star_rail/config/schema/game/fps_unlocker/mod.rs
+++ b/src/games/star_rail/config/schema/game/fps_unlocker/mod.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+
+use serde::{Serialize, Deserialize};
+use serde_json::Value as JsonValue;
+
+use crate::star_rail::consts::launcher_dir;
+
+pub mod config;
+
+pub mod prelude {
+    pub use super::config::Config as FpsUnlockerConfig;
+}
+
+use prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FpsUnlocker {
+    pub path: PathBuf,
+    pub enabled: bool,
+    pub config: FpsUnlockerConfig
+}
+
+impl Default for FpsUnlocker {
+    fn default() -> Self {
+        let launcher_dir = launcher_dir().expect("Failed to get launcher dir");
+
+        Self {
+            path: launcher_dir.join("fps-unlocker"),
+            enabled: true,
+            config: FpsUnlockerConfig::default()
+        }
+    }
+}
+
+impl From<&JsonValue> for FpsUnlocker {
+    fn from(value: &JsonValue) -> Self {
+        let default = Self::default();
+
+        Self {
+            path: match value.get("path") {
+                Some(value) => match value.as_str() {
+                    Some(value) => PathBuf::from(value),
+                    None => default.path
+                },
+                None => default.path
+            },
+
+            enabled: match value.get("enabled") {
+                Some(value) => value.as_bool().unwrap_or(default.enabled),
+                None => default.enabled
+            },
+
+            config: match value.get("config") {
+                Some(value) => FpsUnlockerConfig::from(value),
+                None => default.config
+            }
+        }
+    }
+}

--- a/src/games/star_rail/config/schema/game/mod.rs
+++ b/src/games/star_rail/config/schema/game/mod.rs
@@ -13,12 +13,21 @@ crate::config_impl_dxvk_schema!(launcher_dir);
 pub mod enhancements;
 pub mod paths;
 
+#[cfg(feature = "fps-unlocker")]
+pub mod fps_unlocker;
+
 pub mod prelude {
     pub use super::Wine;
     pub use super::Dxvk;
 
+    #[cfg(feature = "fps-unlocker")]
+    pub use super::fps_unlocker::prelude::*;
+
     pub use super::enhancements::Enhancements;
     pub use super::paths::Paths;
+
+    #[cfg(feature = "fps-unlocker")]
+    pub use super::fps_unlocker::FpsUnlocker;
 }
 
 use prelude::*;

--- a/src/games/star_rail/fps_unlocker/config_schema.rs
+++ b/src/games/star_rail/fps_unlocker/config_schema.rs
@@ -1,0 +1,30 @@
+use serde::{Serialize, Deserialize};
+
+use super::FpsUnlockerConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(non_snake_case)]
+pub struct ConfigSchema {
+    pub FPSTarget: u64
+}
+
+impl Default for ConfigSchema {
+    fn default() -> Self {
+        Self {
+            FPSTarget: 60
+        }
+    }
+}
+
+impl ConfigSchema {
+    pub fn from_config(config: FpsUnlockerConfig) -> Self {
+        Self {
+            FPSTarget: config.fps,
+            ..Self::default()
+        }
+    }
+
+    pub fn json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+}

--- a/src/games/star_rail/fps_unlocker/mod.rs
+++ b/src/games/star_rail/fps_unlocker/mod.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+
+use md5::{Md5, Digest};
+
+use anime_game_core::installer::downloader::Downloader;
+
+use super::config::schema::prelude::FpsUnlockerConfig;
+
+pub mod config_schema;
+
+const UNLOCKER_NAME: &str = "fps_unlocker.sh";
+
+const LATEST_INFO: (&str, &str) = (
+    "aebe0a00bdb560dd5518fe945977d51c",
+    "https://gist.githubusercontent.com/averageFOSSenjoyer/72af30a547088c9169628cafb075ee35/raw/0a2cf8f132420b4747364bb7b2367e339d1b7993/fps_unlocker.sh"
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FpsUnlocker {
+    dir: PathBuf
+}
+
+impl FpsUnlocker {
+    pub fn from_dir<T: Into<PathBuf> + std::fmt::Debug>(dir: T) -> anyhow::Result<Option<Self>> {
+        let dir = dir.into();
+
+        let hash = format!("{:x}", Md5::digest(std::fs::read(dir.join(UNLOCKER_NAME))?));
+
+        Ok(if hash == LATEST_INFO.0 {
+            Some(Self { dir })
+        } else {
+            None
+        })
+    }
+
+    #[tracing::instrument(level = "debug")]
+    pub fn download<T: Into<PathBuf> + std::fmt::Debug>(dir: T) -> anyhow::Result<Self> {
+        tracing::debug!("Downloading FPS unlocker");
+
+        let mut downloader = Downloader::new(LATEST_INFO.1)?;
+
+        let dir = dir.into();
+
+        // Create FPS unlocker folder if needed
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir)?;
+        }
+
+        match downloader.download(dir.join(UNLOCKER_NAME), |_, _| {}) {
+            Ok(_) => Ok(Self { dir }),
+            Err(err) => {
+                tracing::error!("Downloading failed: {err}");
+
+                Err(err.into())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn get_script_in<T: Into<PathBuf>>(dir: T) -> PathBuf {
+        dir.into().join(UNLOCKER_NAME)
+    }
+
+    #[tracing::instrument(level = "debug", ret)]
+    pub fn update_config(&self, config: FpsUnlockerConfig) -> anyhow::Result<()> {
+        tracing::debug!("Updating FPS unlocker config");
+
+        let config = config_schema::ConfigSchema::from_config(config);
+
+        Ok(std::fs::write(
+            self.dir.join("fps_config.json"),
+            config.json()?
+        )?)
+    }
+}

--- a/src/games/star_rail/mod.rs
+++ b/src/games/star_rail/mod.rs
@@ -11,3 +11,4 @@ pub mod game;
 
 #[cfg(feature = "sessions")]
 pub mod sessions;
+mod fps_unlocker;


### PR DESCRIPTION
### Notes
It is possible to modify HSR's maximum framerate via modifying the registry. It seems to only be able to take on 30 and 60, which are official options, or 120 which is not official. 

This PR creates the logic for the modifying of the registry using [the script](https://gist.githubusercontent.com/averageFOSSenjoyer/72af30a547088c9169628cafb075ee35/raw/0a2cf8f132420b4747364bb7b2367e339d1b7993/fps_unlocker.sh) during the run workflow. (May be better for the modification to occur when option is selected on UI?)

##### P.S. 
1. Better way to grant perm to the script?
2. Make backup of the registry so it's easy to revert?

### Testing
Only local tests so far, please pull the workspace and test it.