### PR TITLE
Added hash check for fpsunlocker

### DIFF
--- a/src/games/genshin/fps_unlocker.rs
+++ b/src/games/genshin/fps_unlocker.rs
@@ -48,7 +48,20 @@ impl FpsUnlocker {
         }
 
         match downloader.download(dir.join("fpsunlock.exe"), |_, _| {}) {
-            Ok(_) => Ok(Self { dir }),
+            Ok(_) => {
+                match Self::from_dir(dir) {
+                    Ok(Some(me)) => Ok(me),
+                    Ok(None) => {
+                        tracing::error!("Invalid hash");
+                        Err(anyhow::anyhow!("Downloading failed: Invalid hash"))
+                    },
+                    Err(err) => {
+                        tracing::error!("Downloading failed: {err}");
+
+                        Err(err.into())
+                    }
+                }
+            },
             Err(err) => {
                 tracing::error!("Downloading failed: {err}");
 


### PR DESCRIPTION
It reports a "Downloading failed: Invalid hash" error if there's a hash mismatch now