### PR TITLE
fix: handle /home symlinks

### DIFF
--- a/src/games/genshin/consts.rs
+++ b/src/games/genshin/consts.rs
@@ -22,7 +22,7 @@ pub fn launcher_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_DATA_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.local/share"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get launcher's cache dir path
@@ -35,7 +35,7 @@ pub fn cache_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_CACHE_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.cache"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get config file path

--- a/src/games/honkai/consts.rs
+++ b/src/games/honkai/consts.rs
@@ -22,7 +22,7 @@ pub fn launcher_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_DATA_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.local/share"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get launcher's cache dir path
@@ -35,7 +35,7 @@ pub fn cache_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_CACHE_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.cache"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get config file path

--- a/src/games/pgr/consts.rs
+++ b/src/games/pgr/consts.rs
@@ -22,7 +22,7 @@ pub fn launcher_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_DATA_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.local/share"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get launcher's cache dir path
@@ -35,7 +35,7 @@ pub fn cache_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_CACHE_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.cache"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get config file path

--- a/src/games/star_rail/consts.rs
+++ b/src/games/star_rail/consts.rs
@@ -22,7 +22,7 @@ pub fn launcher_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_DATA_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.local/share"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get launcher's cache dir path
@@ -35,7 +35,7 @@ pub fn cache_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_CACHE_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.cache"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get config file path

--- a/src/games/wuwa/consts.rs
+++ b/src/games/wuwa/consts.rs
@@ -22,7 +22,7 @@ pub fn launcher_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_DATA_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.local/share"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get launcher's cache dir path
@@ -35,7 +35,7 @@ pub fn cache_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_CACHE_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.cache"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get config file path

--- a/src/games/zzz/consts.rs
+++ b/src/games/zzz/consts.rs
@@ -22,7 +22,7 @@ pub fn launcher_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_DATA_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.local/share"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get launcher's cache dir path
@@ -35,7 +35,7 @@ pub fn cache_dir() -> anyhow::Result<PathBuf> {
 
     Ok(std::env::var("XDG_CACHE_HOME")
         .or_else(|_| std::env::var("HOME").map(|home| home + "/.cache"))
-        .map(|home| PathBuf::from(home).join(FOLDER_NAME))?)
+        .map(|home| PathBuf::from(home).join(FOLDER_NAME).canonicalize())??)
 }
 
 /// Get config file path


### PR DESCRIPTION
Handle `/home` being a symlink. This should fix ostree based distros such as Fedora Silverblue/Kinoite, Bazzite, etc.