### PR TITLE
feat: new waves patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies.anime-game-core]
 git = "https://github.com/an-anime-team/anime-game-core"
-tag = "1.28.0"
+tag = "1.29.0"
 features = ["all"]
 
 # path = "../anime-game-core" # ! for dev purposes only
@@ -39,7 +39,7 @@ wuwa = ["anime-game-core/wuwa"]
 star-rail-patch = ["anime-game-core/patch-jadeite"]
 honkai-patch = ["anime-game-core/patch-jadeite"]
 pgr-patch = ["anime-game-core/patch-mfc140"]
-wuwa-patch = ["anime-game-core/patch-vcrun2015"]
+wuwa-patch = ["anime-game-core/patch-jadeite"]
 
 # Common features
 states = []

--- a/src/games/wuwa/config/schema/game/enhancements.rs
+++ b/src/games/wuwa/config/schema/game/enhancements.rs
@@ -9,7 +9,8 @@ pub struct Enhancements {
     pub gamemode: bool,
     pub hud: HUD,
     pub gamescope: Gamescope,
-    pub dx11: bool
+    pub dx11: bool,
+    pub fix_launch_dialog: bool
 }
 
 impl From<&JsonValue> for Enhancements {
@@ -35,7 +36,11 @@ impl From<&JsonValue> for Enhancements {
 
             dx11: value.get("dx11")
                 .and_then(JsonValue::as_bool)
-                .unwrap_or(true)
+                .unwrap_or(true),
+
+            fix_launch_dialog: value.get("fix_launch_dialog")
+                .and_then(JsonValue::as_bool)
+                .unwrap_or(true),
         }
     }
 }

--- a/src/games/wuwa/config/schema/game/enhancements.rs
+++ b/src/games/wuwa/config/schema/game/enhancements.rs
@@ -8,7 +8,8 @@ pub struct Enhancements {
     pub fsr: Fsr,
     pub gamemode: bool,
     pub hud: HUD,
-    pub gamescope: Gamescope
+    pub gamescope: Gamescope,
+    pub dx11: bool
 }
 
 impl From<&JsonValue> for Enhancements {
@@ -30,7 +31,11 @@ impl From<&JsonValue> for Enhancements {
 
             gamescope: value.get("gamescope")
                 .map(Gamescope::from)
-                .unwrap_or(default.gamescope)
+                .unwrap_or(default.gamescope),
+
+            dx11: value.get("dx11")
+                .and_then(JsonValue::as_bool)
+                .unwrap_or(true)
         }
     }
 }

--- a/src/games/wuwa/config/schema/mod.rs
+++ b/src/games/wuwa/config/schema/mod.rs
@@ -19,6 +19,7 @@ use crate::components::{
 
 pub mod launcher;
 pub mod game;
+pub mod patch;
 
 #[cfg(feature = "components")]
 pub mod components;
@@ -27,6 +28,7 @@ pub mod prelude {
     pub use super::launcher::prelude::*;
     pub use super::game::prelude::*;
     pub use super::game::*;
+    pub use super::patch::*;
 
     #[cfg(feature = "components")]
     pub use super::components::*;
@@ -43,7 +45,9 @@ pub struct Schema {
     pub sandbox: Sandbox,
 
     #[cfg(feature = "components")]
-    pub components: Components
+    pub components: Components,
+
+    pub patch: Patch
 }
 
 impl From<&JsonValue> for Schema {
@@ -71,7 +75,12 @@ impl From<&JsonValue> for Schema {
             components: match value.get("components") {
                 Some(value) => Components::from(value),
                 None => default.components
-            }
+            },
+
+            patch: match value.get("patch") {
+                Some(value) => Patch::from(value),
+                None => default.patch
+            },
         }
     }
 }

--- a/src/games/wuwa/config/schema/patch.rs
+++ b/src/games/wuwa/config/schema/patch.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use serde::{Serialize, Deserialize};
+use serde_json::Value as JsonValue;
+
+use crate::wuwa::consts::launcher_dir;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Patch {
+    pub path: PathBuf
+}
+
+impl Default for Patch {
+    #[inline]
+    fn default() -> Self {
+        let launcher_dir = launcher_dir().expect("Failed to get launcher dir");
+
+        Self {
+            path: launcher_dir.join("patch")
+        }
+    }
+}
+
+impl From<&JsonValue> for Patch {
+    fn from(value: &JsonValue) -> Self {
+        let default = Self::default();
+
+        Self {
+            path: match value.get("path").and_then(|path| path.as_str()).map(PathBuf::from) {
+                Some(path) => path,
+                None => default.path
+            }
+        }
+    }
+}

--- a/src/games/wuwa/game.rs
+++ b/src/games/wuwa/game.rs
@@ -197,9 +197,6 @@ pub fn run() -> anyhow::Result<()> {
     command.env("WINEARCH", "win64");
     command.env("WINEPREFIX", &folders.prefix);
 
-    // Special wuwa fix
-    command.env("WINEDLLOVERRIDES", "KRSDKExternal.exe=");
-
     // Add environment flags for selected wine
     for (key, value) in features.env.into_iter() {
         command.env(key, replace_keywords(value, &folders));

--- a/src/games/wuwa/game.rs
+++ b/src/games/wuwa/game.rs
@@ -24,6 +24,7 @@ struct Folders {
     pub wine: PathBuf,
     pub prefix: PathBuf,
     pub game: PathBuf,
+    pub patch: PathBuf,
     pub temp: PathBuf
 }
 
@@ -44,8 +45,9 @@ pub fn run() -> anyhow::Result<()> {
     tracing::info!("Preparing to run the game");
 
     let config = Config::get()?;
+    let game_path = config.game.path.for_edition(config.launcher.edition).to_path_buf();
 
-    if !config.game.path.for_edition(config.launcher.edition).exists() {
+    if !game_path.exists() {
         return Err(anyhow::anyhow!("Game is not installed"));
     }
 
@@ -58,7 +60,8 @@ pub fn run() -> anyhow::Result<()> {
     let mut folders = Folders {
         wine: config.game.wine.builds.join(&wine.name),
         prefix: config.game.wine.prefix.clone(),
-        game: config.game.path.for_edition(config.launcher.edition).to_path_buf(),
+        game: game_path.clone(),
+        patch: config.patch.path.clone(),
         temp: config.launcher.temp.clone().unwrap_or(std::env::temp_dir())
     };
 
@@ -75,10 +78,12 @@ pub fn run() -> anyhow::Result<()> {
 
     config.game.wine.drives.map_folders(&folders.game, &prefix_folder)?;
 
+    // Workaround for the jadeite patch (we run it from Z: drive)
+    WineDrives::map_folder(&prefix_folder, AllowedDrives::Z, "/")?;
+
     // Workaround for sandboxing feature
     if config.sandbox.enabled {
         WineDrives::map_folder(&prefix_folder, AllowedDrives::C, "../drive_c")?;
-        WineDrives::map_folder(&prefix_folder, AllowedDrives::Z, "/")?;
     }
 
     // Prepare bash -c '<command>'
@@ -99,12 +104,12 @@ pub fn run() -> anyhow::Result<()> {
     bash_command += &run_command;
     bash_command += " ";
 
-    if let Some(virtual_desktop) = config.game.wine.virtual_desktop.get_command("pgr") {
+    if let Some(virtual_desktop) = config.game.wine.virtual_desktop.get_command("wuwa") {
         windows_command += &virtual_desktop;
         windows_command += " ";
     }
 
-    windows_command += "Client/Binaries/Win64/Client-Win64-Shipping.exe ";
+    windows_command += &format!("'{}/jadeite.exe' 'Z:\\{}/Client/Binaries/Win64/Client-Win64-Shipping.exe' -- ", folders.patch.to_string_lossy(), folders.game.to_string_lossy());
 
     if config.game.wine.borderless {
         launch_args += "-screen-fullscreen 0 -popupwindow ";
@@ -137,10 +142,13 @@ pub fn run() -> anyhow::Result<()> {
             folders.game.to_str().unwrap()
         );
 
+        let bwrap = format!("{bwrap} --bind '{}' /tmp/sandbox/patch", folders.patch.to_string_lossy());
+
         let sandboxed_folders = Folders {
             wine: PathBuf::from("/tmp/sandbox/wine"),
             prefix: PathBuf::from("/tmp/sandbox/prefix"),
             game: PathBuf::from("/tmp/sandbox/game"),
+            patch: PathBuf::from("/tmp/sandbox/patch"),
             temp: PathBuf::from("/tmp")
         };
 
@@ -148,12 +156,14 @@ pub fn run() -> anyhow::Result<()> {
             .replace(folders.wine.to_str().unwrap(), sandboxed_folders.wine.to_str().unwrap())
             .replace(folders.prefix.to_str().unwrap(), sandboxed_folders.prefix.to_str().unwrap())
             .replace(folders.game.to_str().unwrap(), sandboxed_folders.game.to_str().unwrap())
+            .replace(folders.patch.to_str().unwrap(), sandboxed_folders.patch.to_str().unwrap())
             .replace(folders.temp.to_str().unwrap(), sandboxed_folders.temp.to_str().unwrap());
 
         windows_command = windows_command
             .replace(folders.wine.to_str().unwrap(), sandboxed_folders.wine.to_str().unwrap())
             .replace(folders.prefix.to_str().unwrap(), sandboxed_folders.prefix.to_str().unwrap())
             .replace(folders.game.to_str().unwrap(), sandboxed_folders.game.to_str().unwrap())
+            .replace(folders.patch.to_str().unwrap(), sandboxed_folders.patch.to_str().unwrap())
             .replace(folders.temp.to_str().unwrap(), sandboxed_folders.temp.to_str().unwrap());
 
         bash_command = format!("{bwrap} --chdir /tmp/sandbox/game -- {bash_command}");

--- a/src/games/wuwa/game.rs
+++ b/src/games/wuwa/game.rs
@@ -125,6 +125,10 @@ pub fn run() -> anyhow::Result<()> {
         bash_command = format!("{gamescope} -- {bash_command}");
     }
 
+    if config.game.enhancements.dx11 {
+        launch_args += "-dx11 ";
+    }
+
     // Bundle all windows arguments used to run the game into a single file
     if features.compact_launch {
         std::fs::write(folders.game.join("compact_launch.bat"), format!("start {windows_command} {launch_args}\nexit"))?;


### PR DESCRIPTION
Adds support for the new waves patch

Also adds two waves-specific game enhancements:
- `dx11` - forces dx11 mode (enabled by default)
- `fix_launch_dialog` - fixes the blank window dialog when the game starts (also enabled by default)

I bumped the anime-game-core dependency to `1.29.0` which I guess should be the next version after https://github.com/an-anime-team/anime-game-core/pull/16 gets merged