### PR TITLE
Do not crash when internet is disconnected

### DIFF
--- a/src/games/genshin/states.rs
+++ b/src/games/genshin/states.rs
@@ -79,8 +79,15 @@ impl LauncherState {
 
         let game = Game::new(&params.game_path, params.game_edition);
 
-        let diff = game.try_get_diff()?;
+        let try_diff = game.try_get_diff();
 
+        if try_diff.is_err() {
+            // Cannot check game state(e.g. internet is disconnected), assume it's latest.
+            tracing::warn!("Failed to check game state: {}. Assuming the game is the latest", try_diff.unwrap_err());
+            return Ok(Self::Launch);
+        }
+
+        let diff = try_diff.unwrap();
         match diff {
             VersionDiff::Latest { .. } | VersionDiff::Predownload { .. } => {
                 let mut predownload_voice = Vec::new();


### PR DESCRIPTION
Context: https://github.com/an-anime-team/an-anime-game-launcher/issues/483

Users has to disconnect the internet, launch the game then connect the internet in order to start the game. It's better to support launching the game without internet connected.

Problem: Currently the launcher requires internet to be connected otherwise it crashes as it cannot detect the game version.

Change: Try to detect the game version, but if it fails just assume it is the latest version.