### PR TITLE
Fix mapping game folder after game installation was manually moved

### DIFF
--- a/src/config/schema_blanks/wine/wine_drives.rs
+++ b/src/config/schema_blanks/wine/wine_drives.rs
@@ -97,8 +97,10 @@ impl WineDrives {
             .join("dosdevices")
             .join(drive.to_drive());
 
-        if drive_folder.exists() {
-            std::fs::remove_file(&drive_folder)?;
+        match std::fs::remove_file(&drive_folder) {
+            Ok(_) => {},
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {},
+            Err(e) => return Err(e.into()),
         }
 
         std::os::unix::fs::symlink(symlink_folder.as_ref(), drive_folder)?;


### PR DESCRIPTION
`drive_folder.exists()` was returning false for a symlink that existed but pointed to invalid location (such as when someone moved the game installation, adjusted config json, and then tried launching the game). Then trying to create a symlink over one that existed would throw an error (`File exists (os error 17)`).

I could've used `is_symlink()` next to `exists()` instead, but I decided for this approach, as it also avoids race condition between checking and actually deleting. So right now it will just try to delete it and silently eat a NotFound exception (whereas exceptions such as no permissions etc. will still be thrown). I hope it makes sense, should be the best approach.

Fixes an-anime-team/an-anime-game-launcher#268
Fixes an-anime-team/an-anime-game-launcher#322
Fixes an-anime-team/an-anime-game-launcher#124
Fixes an-anime-team/an-anime-game-launcher#433
Fixes an-anime-team/the-honkers-railway-launcher#91
(and maybe more, but found just these so far xD)

I tested that it fixes the issue:
- invalid symlink exists, before patch → error
- invalid symlink exists, after patch → works
- missing symlink, after patch → still works (so that means NotFound error is silently ignored as expected)

see also comment: https://github.com/an-anime-team/an-anime-game-launcher/issues/268#issuecomment-1826893795