### PR TITLE
feat: added DXVK installation check

### DIFF
--- a/src/games/genshin/states.rs
+++ b/src/games/genshin/states.rs
@@ -29,6 +29,8 @@ pub enum LauncherState {
 
     PrefixNotExists,
 
+    DxvkNotInstalled,
+
     // Always contains `VersionDiff::Diff`
     VoiceUpdateAvailable(VersionDiff),
 
@@ -72,6 +74,23 @@ impl LauncherState {
         // Check prefix existence
         if !params.wine_prefix.join("drive_c").exists() {
             return Ok(Self::PrefixNotExists);
+        }
+
+        // Check dxvk installation
+        let reg_path = params.wine_prefix.join("user.reg");
+        let reg_content = std::fs::read_to_string(&reg_path)?;
+        let mut found_dxgi = false;
+
+        for line in reg_content.lines() {
+            if line.trim_start().starts_with("\"dxgi\"") {
+                found_dxgi = true;
+                if !line.contains("\"native\"") {
+                    return Ok(Self::DxvkNotInstalled);
+                }
+            }
+        }
+        if !found_dxgi {
+           return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status

--- a/src/games/genshin/states.rs
+++ b/src/games/genshin/states.rs
@@ -77,20 +77,25 @@ impl LauncherState {
         }
 
         // Check dxvk installation
+ 
         let reg_path = params.wine_prefix.join("user.reg");
+
         let reg_content = std::fs::read_to_string(&reg_path)?;
+
         let mut found_dxgi = false;
 
         for line in reg_content.lines() {
             if line.trim_start().starts_with("\"dxgi\"") {
                 found_dxgi = true;
+                
                 if !line.contains("\"native\"") {
                     return Ok(Self::DxvkNotInstalled);
                 }
             }
         }
+
         if !found_dxgi {
-           return Ok(Self::DxvkNotInstalled);
+            return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status

--- a/src/games/honkai/states.rs
+++ b/src/games/honkai/states.rs
@@ -62,20 +62,25 @@ impl LauncherState {
         }
 
         // Check dxvk installation
+ 
         let reg_path = params.wine_prefix.join("user.reg");
+
         let reg_content = std::fs::read_to_string(&reg_path)?;
+
         let mut found_dxgi = false;
 
         for line in reg_content.lines() {
             if line.trim_start().starts_with("\"dxgi\"") {
                 found_dxgi = true;
+                
                 if !line.contains("\"native\"") {
                     return Ok(Self::DxvkNotInstalled);
                 }
             }
         }
+
         if !found_dxgi {
-           return Ok(Self::DxvkNotInstalled);
+            return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status

--- a/src/games/honkai/states.rs
+++ b/src/games/honkai/states.rs
@@ -25,6 +25,8 @@ pub enum LauncherState {
 
     PrefixNotExists,
 
+    DxvkNotInstalled,
+
     // Always contains `VersionDiff::Diff`
     GameUpdateAvailable(VersionDiff),
 
@@ -57,6 +59,23 @@ impl LauncherState {
         // Check prefix existence
         if !params.wine_prefix.join("drive_c").exists() {
             return Ok(Self::PrefixNotExists);
+        }
+
+        // Check dxvk installation
+        let reg_path = params.wine_prefix.join("user.reg");
+        let reg_content = std::fs::read_to_string(&reg_path)?;
+        let mut found_dxgi = false;
+
+        for line in reg_content.lines() {
+            if line.trim_start().starts_with("\"dxgi\"") {
+                found_dxgi = true;
+                if !line.contains("\"native\"") {
+                    return Ok(Self::DxvkNotInstalled);
+                }
+            }
+        }
+        if !found_dxgi {
+           return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status

--- a/src/games/star_rail/states.rs
+++ b/src/games/star_rail/states.rs
@@ -25,6 +25,8 @@ pub enum LauncherState {
 
     PrefixNotExists,
 
+    DxvkNotInstalled,
+
     /// Always contains `VersionDiff::Predownload`
     PredownloadAvailable {
         game: VersionDiff,
@@ -77,6 +79,23 @@ impl LauncherState {
         // Check prefix existence
         if !params.wine_prefix.join("drive_c").exists() {
             return Ok(Self::PrefixNotExists);
+        }
+
+        // Check dxvk installation
+        let reg_path = params.wine_prefix.join("user.reg");
+        let reg_content = std::fs::read_to_string(&reg_path)?;
+        let mut found_dxgi = false;
+
+        for line in reg_content.lines() {
+            if line.trim_start().starts_with("\"dxgi\"") {
+                found_dxgi = true;
+                if !line.contains("\"native\"") {
+                    return Ok(Self::DxvkNotInstalled);
+                }
+            }
+        }
+        if !found_dxgi {
+           return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status

--- a/src/games/star_rail/states.rs
+++ b/src/games/star_rail/states.rs
@@ -82,20 +82,25 @@ impl LauncherState {
         }
 
         // Check dxvk installation
+ 
         let reg_path = params.wine_prefix.join("user.reg");
+
         let reg_content = std::fs::read_to_string(&reg_path)?;
+
         let mut found_dxgi = false;
 
         for line in reg_content.lines() {
             if line.trim_start().starts_with("\"dxgi\"") {
                 found_dxgi = true;
+                
                 if !line.contains("\"native\"") {
                     return Ok(Self::DxvkNotInstalled);
                 }
             }
         }
+
         if !found_dxgi {
-           return Ok(Self::DxvkNotInstalled);
+            return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status

--- a/src/games/zzz/states.rs
+++ b/src/games/zzz/states.rs
@@ -28,6 +28,8 @@ pub enum LauncherState {
 
     PrefixNotExists,
 
+    DxvkNotInstalled,
+
     // Always contains `VersionDiff::Diff`
     VoiceUpdateAvailable(VersionDiff),
 
@@ -68,6 +70,23 @@ impl LauncherState {
         // Check prefix existence
         if !params.wine_prefix.join("drive_c").exists() {
             return Ok(Self::PrefixNotExists);
+        }
+
+        // Check dxvk installation
+        let reg_path = params.wine_prefix.join("user.reg");
+        let reg_content = std::fs::read_to_string(&reg_path)?;
+        let mut found_dxgi = false;
+
+        for line in reg_content.lines() {
+            if line.trim_start().starts_with("\"dxgi\"") {
+                found_dxgi = true;
+                if !line.contains("\"native\"") {
+                    return Ok(Self::DxvkNotInstalled);
+                }
+            }
+        }
+        if !found_dxgi {
+           return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status

--- a/src/games/zzz/states.rs
+++ b/src/games/zzz/states.rs
@@ -73,20 +73,25 @@ impl LauncherState {
         }
 
         // Check dxvk installation
+ 
         let reg_path = params.wine_prefix.join("user.reg");
+
         let reg_content = std::fs::read_to_string(&reg_path)?;
+
         let mut found_dxgi = false;
 
         for line in reg_content.lines() {
             if line.trim_start().starts_with("\"dxgi\"") {
                 found_dxgi = true;
+                
                 if !line.contains("\"native\"") {
                     return Ok(Self::DxvkNotInstalled);
                 }
             }
         }
+
         if !found_dxgi {
-           return Ok(Self::DxvkNotInstalled);
+            return Ok(Self::DxvkNotInstalled);
         }
 
         // Check game installation status


### PR DESCRIPTION
Solution to the very common issue of broken DXVK installations in the various launchers: checking if DXVK is actually installed before allowing launching the game. 
Simply parsing the Wine registry is indeed enough to see if the overrides applied correctly.

The "checking on launch" part will be handled by the various launchers, as well as re-installing DXVK if necessary.