### PR TITLE
Fix custom game paths in launch commands

### DIFF
--- a/src/games/genshin/game.rs
+++ b/src/games/genshin/game.rs
@@ -163,10 +163,12 @@ pub fn run() -> anyhow::Result<bool> {
         .drives
         .map_folders(&folders.game, &config.game.wine.prefix)?;
 
+    // Use an absolute Wine path when launching the game
+    WineDrives::map_folder(&config.game.wine.prefix, AllowedDrives::Z, "/")?;
+
     // Workaround for sandboxing feature
     if config.sandbox.enabled {
         WineDrives::map_folder(&config.game.wine.prefix, AllowedDrives::C, "../drive_c")?;
-        WineDrives::map_folder(&config.game.wine.prefix, AllowedDrives::Z, "/")?;
     }
 
     // Prepare bash -c '<command>'
@@ -204,8 +206,11 @@ pub fn run() -> anyhow::Result<bool> {
         windows_command += " ";
     }
 
-    windows_command += game_executable;
-    windows_command += " ";
+    windows_command += &format!(
+        "'Z:\\{}/{}' ",
+        folders.game.to_string_lossy(),
+        game_executable
+    );
 
     if config.game.wine.borderless {
         launch_args += "-screen-fullscreen 0 -popupwindow ";

--- a/src/games/zzz/game.rs
+++ b/src/games/zzz/game.rs
@@ -101,10 +101,12 @@ pub fn run() -> anyhow::Result<bool> {
     // Prepare wine prefix drives
     config.game.wine.drives.map_folders(&folders.game, &config.game.wine.prefix)?;
 
+    // Use an absolute Wine path when launching the game
+    WineDrives::map_folder(&config.game.wine.prefix, AllowedDrives::Z, "/")?;
+
     // Workaround for sandboxing feature
     if config.sandbox.enabled {
         WineDrives::map_folder(&config.game.wine.prefix, AllowedDrives::C, "../drive_c")?;
-        WineDrives::map_folder(&config.game.wine.prefix, AllowedDrives::Z, "/")?;
     }
 
     // Prepare bash -c '<command>'
@@ -130,7 +132,10 @@ pub fn run() -> anyhow::Result<bool> {
         windows_command += " ";
     }
 
-    windows_command += "ZenlessZoneZero.exe ";
+    windows_command += &format!(
+        "'Z:\\{}/ZenlessZoneZero.exe' ",
+        folders.game.to_string_lossy()
+    );
 
     if config.game.wine.borderless {
         launch_args += "-screen-fullscreen 0 -popupwindow ";
@@ -167,6 +172,11 @@ pub fn run() -> anyhow::Result<bool> {
             .replace(folders.prefix.to_str().unwrap(), sandboxed_folders.prefix.to_str().unwrap())
             .replace(folders.game.to_str().unwrap(), sandboxed_folders.game.to_str().unwrap())
             .replace(folders.temp.to_str().unwrap(), sandboxed_folders.temp.to_str().unwrap());
+
+        windows_command = windows_command.replace(
+            folders.game.to_str().unwrap(),
+            sandboxed_folders.game.to_str().unwrap()
+        );
 
         bash_command = format!("{bwrap} --chdir /tmp/sandbox/game -- {bash_command}");
         folders = sandboxed_folders;


### PR DESCRIPTION
Launch commands currently use only the executable name, so a custom install directory can be lost when the command is wrapped.

Use the configured game directory through Wine's Z: drive and rewrite the path for bwrap before building the final command.

Fixes #36.